### PR TITLE
FIX Replace Convert JSON methods with json_* methods, deprecated from SilverStripe 4.4

### DIFF
--- a/src/Block/BannerBlock.php
+++ b/src/Block/BannerBlock.php
@@ -87,7 +87,7 @@ class BannerBlock extends FileBlock
             return;
         }
 
-        $data = ArrayData::create(Convert::json2obj($linkJson));
+        $data = ArrayData::create(json_decode($linkJson));
 
         // Link page, if selected
         if ($data->PageID) {

--- a/src/Form/BlockLinkField.php
+++ b/src/Form/BlockLinkField.php
@@ -52,7 +52,7 @@ class BlockLinkField extends FormField
             return $this->parsedValue;
         }
 
-        $parsedValue = Convert::json2array($this->dataValue());
+        $parsedValue = json_decode($this->dataValue(), true);
         return $this->parsedValue = ArrayData::create((array) $parsedValue);
     }
 


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/8424