### PR TITLE
Guard creation of behat context class

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,5 +7,6 @@
         <!-- Current exclusions -->
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
         <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols" />
     </rule>
 </ruleset>

--- a/tests/Behat/Context/FeatureContext.php
+++ b/tests/Behat/Context/FeatureContext.php
@@ -4,6 +4,10 @@ namespace SilverStripe\ElementalBannerBlock\Tests\Behat\Context;
 use Behat\Mink\Element\NodeElement;
 use DNADesign\Elemental\Tests\Behat\Context\FeatureContext as BaseFeatureContext;
 
+if (!class_exists(BaseFeatureContext::class)) {
+    return;
+}
+
 class FeatureContext extends BaseFeatureContext
 {
     /**


### PR DESCRIPTION
if the parent class does not exist then it will cause an error - which
will e.g. cause CI builds to fail in travis with
silverstripe/recipe-content-blocks