### PR TITLE
Guard creation of Behat fixture context class

### DIFF
--- a/tests/Behat/Context/FixtureContext.php
+++ b/tests/Behat/Context/FixtureContext.php
@@ -7,6 +7,10 @@ use SilverStripe\Assets\Image;
 use SilverStripe\BehatExtension\Context\FixtureContext as BaseFixtureContext;
 use SilverStripe\ElementalBannerBlock\Block\BannerBlock;
 
+if (!class_exists(BaseFixtureContext::class)) {
+    return;
+}
+
 /**
  * Context used to create fixtures in the SilverStripe ORM.
  */


### PR DESCRIPTION
if the parent class does not exist then it will cause an error - which
will e.g. cause CI builds to fail in travis with
silverstripe/recipe-content-blocks