### PR TITLE
FIX Duplicate requirements calls have been removed, now applied to LeftAndMain with inline editing

### DIFF
--- a/src/Block/BannerBlock.php
+++ b/src/Block/BannerBlock.php
@@ -3,12 +3,9 @@
 namespace SilverStripe\ElementalBannerBlock\Block;
 
 use SilverStripe\CMS\Model\SiteTree;
-use SilverStripe\Core\Convert;
 use SilverStripe\ElementalFileBlock\Block\FileBlock;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 use SilverStripe\View\ArrayData;
-use SilverStripe\View\Requirements;
 
 class BannerBlock extends FileBlock
 {
@@ -46,11 +43,6 @@ class BannerBlock extends FileBlock
             $fields->fieldByName('Root.Main.CallToActionLink')
                 ->setTitle(_t(__CLASS__ . '.CallToActionTitle', 'Call to action link'));
         });
-
-        // Ensure TinyMCE's javascript is loaded before the blocks overrides
-        Requirements::javascript(TinyMCEConfig::get()->getScriptURL());
-        Requirements::javascript('silverstripe/elemental-bannerblock:client/dist/js/bundle.js');
-        Requirements::css('silverstripe/elemental-bannerblock:client/dist/styles/bundle.css');
 
         return parent::getCMSFields();
     }

--- a/tests/Behat/features/element-editor.feature
+++ b/tests/Behat/features/element-editor.feature
@@ -1,8 +1,8 @@
 @javascript
-Feature: View types of elements in a report
+Feature: Manage banner blocks
   As a CMS user
-  I want to view a list of elements in the CMS
-  So that I can see which elements I have used on a page
+  I want to manage banner blocks in the CMS
+  So that I can add banners to my content block pages
 
   Background:
     Given I add an extension "DNADesign\Elemental\Extensions\ElementalPageExtension" to the "Page" class
@@ -31,7 +31,7 @@ Feature: View types of elements in a report
     When I see a list of blocks
     Then I press the "Add block" button
       And I press the "Banner" button in the add block popover
-      And I wait 5 second
+      And I wait 5 seconds
     Then I should see "Untitled Banner block" as the title for block 1
 
     Given I click on block 1

--- a/tests/Block/BannerBlockTest.php
+++ b/tests/Block/BannerBlockTest.php
@@ -13,27 +13,6 @@ class BannerBlockTest extends SapphireTest
 {
     protected static $fixture_file = 'BannerBlockTest.yml';
 
-    public function testTinyMceJavascriptIsRequiredBeforeBlocks()
-    {
-        $block = new BannerBlock;
-        $block->getCMSFields();
-
-        $javascript = Requirements::backend()->getJavascript();
-
-        // Ensure TinyMCE's scripts are loaded first
-        $mcePath = TinyMCEConfig::get()->getScriptURL();
-        $this->assertArrayHasKey($mcePath, $javascript, 'TinyMCE is loaded first');
-
-        // By pushing the bundle reference again, the size of the requirements shouldn't change
-        $this->assertNotEmpty($javascript);
-        Requirements::javascript('silverstripe/elemental-bannerblock:client/dist/js/bundle.js');
-        $this->assertSame(
-            count($javascript),
-            count(Requirements::backend()->getJavascript()),
-            'Blocks bundle is added'
-        );
-    }
-
     public function testCallToActionLink()
     {
         $block = new BannerBlock;


### PR DESCRIPTION
This was causing Behat failures. The Requirements calls are no longer required since the bundles are added to LeftAndMain. Also updated the behat feature description.

Fixes https://github.com/dnadesign/silverstripe-elemental/issues/563