### PR TITLE
FIX Handle string null CallToActionLink in database

### DIFF
--- a/src/Block/BannerBlock.php
+++ b/src/Block/BannerBlock.php
@@ -48,7 +48,21 @@ class BannerBlock extends FileBlock
     }
 
     /**
-     * For the frontend, return a parsed set of data for use in templates
+     * Accessor for `CallToActionLink` i.e. $block->CallToActionLink
+     *
+     * @return string|null
+     */
+    public function getCallToActionLink()
+    {
+        // returns the value of the database column which is a json encoded string.
+        // If there is old data where null was mistakenly saved as a string 'null'
+        // then convert that to null
+        $callToActionLink = $this->getField('CallToActionLink');
+        return $callToActionLink === 'null' ? null : $callToActionLink;
+    }
+
+    /**
+     * Used for the frontend templates, returns a parsed set of data
      *
      * @return ArrayData|null
      */
@@ -90,6 +104,8 @@ class BannerBlock extends FileBlock
      */
     protected function decodeLinkData($linkJson)
     {
+        // $linkJson === 'null' is to fix a bug in older versioned of versioned-admin
+        // which saved <null> as 'null'
         if (!$linkJson || $linkJson === 'null') {
             return;
         }

--- a/tests/Block/BannerBlockTest.php
+++ b/tests/Block/BannerBlockTest.php
@@ -31,4 +31,14 @@ class BannerBlockTest extends SapphireTest
         $this->assertInstanceOf(SiteTree::class, $result->Page);
         $this->assertSame('Link title text', $result->Description, 'Link attributes are available');
     }
+
+    public function testNullStringCallToActionLink()
+    {
+        // test that data incorrectly saved as a string 'null' is converted to null on get
+        // https://github.com/silverstripe/silverstripe-elemental-bannerblock/issues/30#issuecomment-555460856
+        $block = BannerBlock::create();
+        $block->CallToActionLink = 'null';
+        $block->write();
+        $this->assertNull($block->CallToActionLink());
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-elemental-bannerblock/issues/30

See comment https://github.com/silverstripe/silverstripe-elemental-bannerblock/issues/30#issuecomment-555460856
