### PR TITLE
ENH Update singular and plural names to banner block(s)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,25 @@
 language: php
 
-dist: trusty
+dist: xenial
 
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install chromium-chromedriver
+services:
+  - mysql
+  - postgresql
+  - xvfb
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+addons:
+  apt:
+    packages:
+      - tidy
+      - chromium-chromedriver
+      - chromium-browser
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION="2.1.x-dev"
     - DISPLAY=":99"
     - XVFBARGS=":99 -ac -screen 0 1024x768x16"
     - SS_BASE_URL="http://localhost:8080/"
@@ -16,18 +27,14 @@ env:
 
 matrix:
   include:
-    - php: 5.6
-      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1
-    - php: 7.0
-      env: DB=PGSQL PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1
+      env: DB=PGSQL INSTALLER_VERSION=4.5.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.2
-      env: DB=MYSQL PHPUNIT_TEST=1
-    - php: 7.2
-      env: DB=MYSQL BEHAT_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.6.x-dev BEHAT_TEST=1
     - php: 7.3
-      env: DB=MYSQL PHPUNIT_TEST=1 NPM_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.6.x-dev NPM_TEST=1
+    - php: 7.4
+      env: DB=MYSQL INSTALLER_VERSION=4.x-dev PHPUNIT_COVERAGE_TEST=1
 
 before_script:
   # Extra $PATH
@@ -38,16 +45,22 @@ before_script:
   - echo 'memory_limit = 4096M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
   - composer validate
-  - if [[ $DB == PGSQL ]]; then composer require --prefer-dist --no-update silverstripe/postgresql 2.1.x-dev; fi
-  - composer require --no-update silverstripe/recipe-testing:^1 silverstripe/installer:4.3.x-dev
+  - if [[ $DB == PGSQL ]]; then composer require --prefer-dist --no-update silverstripe/postgresql:^2; fi
+  - composer require --no-update silverstripe/recipe-testing:^1 silverstripe/installer:$INSTALLER_VERSION
   - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
-  # Behat bootstrapping
+  # Remove preinstalled Chrome (google-chrome)
+  # this would conflict with our chromium-browser installation
+  # and its version is incompatible with chromium-chromedriver
+  - sudo apt-get remove -y --purge google-chrome-stable || true
+
+  # Start behat services
   - if [[ $BEHAT_TEST ]]; then mkdir artifacts; fi
   - if [[ $BEHAT_TEST ]]; then cp composer.lock artifacts/; fi
   - if [[ $BEHAT_TEST ]]; then sh -e /etc/init.d/xvfb start; sleep 3; fi
   - if [[ $BEHAT_TEST ]]; then (chromedriver > artifacts/chromedriver.log 2>&1 &); fi
   - if [[ $BEHAT_TEST ]]; then (vendor/bin/serve --bootstrap-file vendor/silverstripe/cms/tests/behat/serve-bootstrap.php &> artifacts/serve.log &); fi
+
 
   # Install NPM dependencies
   - if [[ $NPM_TEST ]]; then nvm install && nvm use && npm install -g yarn && yarn install --network-concurrency 1 && (cd vendor/silverstripe/admin && yarn install --network-concurrency 1); fi

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -2,11 +2,11 @@ en:
   SilverStripe\ElementalBannerBlock\Block\BannerBlock:
     BlockType: Banner
     CallToActionTitle: 'Call to action link'
-    PLURALNAME: banners
+    PLURALNAME: 'banner blocks'
     PLURALS:
-      one: 'A banner'
-      other: '{count} banners'
-    SINGULARNAME: banner
+      one: 'A banner block'
+      other: '{count} banner blocks'
+    SINGULARNAME: 'banner block'
   SilverStripe\ElementalBannerBlock\Form\BlockLinkField:
     Description: 'Link description'
     LinkText: 'Link text'

--- a/src/Block/BannerBlock.php
+++ b/src/Block/BannerBlock.php
@@ -16,9 +16,9 @@ class BannerBlock extends FileBlock
         'CallToActionLink' => 'Link',
     ];
 
-    private static $singular_name = 'banner';
+    private static $singular_name = 'banner block';
 
-    private static $plural_name = 'banners';
+    private static $plural_name = 'banner blocks';
 
     private static $table_name = 'S_EB_BannerBlock';
 


### PR DESCRIPTION
Issue: https://github.com/creative-commoners/silverstripe-elemental-bannerblock/pull/new/pulls/2.1/singular-plural-names

Release 2.1.2 when merged

The two travis failures relate to:
- the javascript was built years ago with node 6 instead of node 10.  This PR doesn't touch the JS dist files though.
- composer complaining about installing recipe-testing on php 7.4 with silverstripe/installer 4.x-dev.  I don't think this has anything to do with the code changes in this PR

The phpunit and behat test matrix entries are green