### PR TITLE
Revert translation update

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -2,11 +2,11 @@ en:
   SilverStripe\ElementalBannerBlock\Block\BannerBlock:
     BlockType: Banner
     CallToActionTitle: 'Call to action link'
-    PLURALNAME: banners
+    PLURALNAME: 'banner blocks'
     PLURALS:
-      one: 'A banner'
-      other: '{count} banners'
-    SINGULARNAME: banner
+      one: 'A banner block'
+      other: '{count} banner blocks'
+    SINGULARNAME: 'banner block'
   SilverStripe\ElementalBannerBlock\Form\BlockLinkField:
     Description: 'Link description'
     LinkText: 'Link text'


### PR DESCRIPTION
Was inadvertently reverted by cow during the last release

It's supposed to be 'banner block(s)' not 'block(s)' https://github.com/silverstripe/silverstripe-elemental-bannerblock/pull/56

Release 2.2.1 when merged, and remember to merge-up to 2