### PR TITLE
Revert translation

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -4,9 +4,9 @@ en:
     CallToActionTitle: 'Call to action link'
     PLURALNAME: banners
     PLURALS:
-      one: 'A banner'
-      other: '{count} banners'
-    SINGULARNAME: banner
+      one: 'A banner block'
+      other: '{count} banner blocks'
+    SINGULARNAME: 'banner block'
   SilverStripe\ElementalBannerBlock\Form\BlockLinkField:
     Description: 'Link description'
     LinkText: 'Link text'


### PR DESCRIPTION
Was inadvertently reverted by cow during the last release

It's supposed to be 'banner block(s)' not 'banner(s)' https://github.com/silverstripe/silverstripe-elemental-bannerblock/pull/56

Release 2.2.1 when merged, and remember to merge-up to 2