### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "silverstripe/vendor-plugin": "^1.0",
-        "dnadesign/silverstripe-elemental": "4.11.x-dev",
-        "silverstripe/elemental-fileblock": "2.5.x-dev",
-        "silverstripe/cms": "4.13.x-dev",
-        "silverstripe/admin": "1.13.x-dev",
-        "silverstripe/framework": "4.13.x-dev"
+        "dnadesign/silverstripe-elemental": "^4.7",
+        "silverstripe/elemental-fileblock": "^2@dev",
+        "silverstripe/cms": "^4.3",
+        "silverstripe/admin": "^1.7@dev",
+        "silverstripe/framework": "^4.10"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

See https://github.com/silverstripe/silverstripe-elemental-bannerblock/commit/344ed133605a02f3f75a8b35d8a184b9109edfab

## Issue
- https://github.com/silverstripe/.github/issues/33