### PR TITLE
MNT Don't click on the block unnecessary in behat test

### DIFF
--- a/tests/Behat/features/block-link-field.feature
+++ b/tests/Behat/features/block-link-field.feature
@@ -25,7 +25,6 @@ Feature: Add link to banner block
     When I press the "Clear link" button in the actions menu for call to action link in block 1
       And I press the "Save" button in the actions menu for block 1
       And I wait 1 second
-      And I click on block 1
     Then I should see the edit form for block 1
       And I should see "Call to action link"
       And I should see "Add link"


### PR DESCRIPTION
Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/10033713755/job/27779110922

> When I click "Add link" in the ".block-link-field" element                                  # SilverStripe\BehatExtension\Context\BasicContext::iClickInTheElement()
      element click intercepted: Element `<span class="block-link-field__content--message-add-link">...</span>` is not clickable at point (449, 633). Other element would receive the click: `<div class="asset-dropzone flexbox-area-grow">...</div>`

This is caused by clicking on the block when it's already expanded, which in the specific circumstances in the kitchen sink behat run results in clicking the upload field, opening the assets modal and therefore intercepting the above mentioned "click".

## Issue
- https://github.com/silverstripe/.github/issues/285