### PR TITLE
ENH Don't use keyword "self"

### DIFF
--- a/src/Block/BannerBlock.php
+++ b/src/Block/BannerBlock.php
@@ -110,7 +110,7 @@ class BannerBlock extends FileBlock
 
         // Link page, if selected
         if ($data->PageID) {
-            $data->setField('Page', self::get_by_id(SiteTree::class, $data->PageID));
+            $data->setField('Page', BannerBlock::get_by_id(SiteTree::class, $data->PageID));
         }
 
         return $data;


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-elemental-bannerblock/actions/runs/10135632357/job/28023263071

> ```
> Error: Can't use keyword 'self'. Use 'BannerBlock' instead.
>  ------ ------------------------------------------------------
>   Line   Block/BannerBlock.php                                 
>  ------ ------------------------------------------------------
>   113    Can't use keyword 'self'. Use 'BannerBlock' instead.  
>  ------ ------------------------------------------------------
> ```

## Issues
- https://github.com/silverstripe/.github/issues/287